### PR TITLE
Lint: Make sure that `prettier-doc/no-concat` is enforced

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,7 @@
 extends:
     - eslint:recommended
     - plugin:prettier/recommended
+    - plugin:prettier-doc/recommended
     - plugin:jest/recommended
 plugins:
     - import
@@ -30,6 +31,7 @@ rules:
         - never
     prefer-arrow-callback: error
     prefer-const: error
+    prettier-doc/no-concat: error
     react/no-deprecated: off
     strict: off
     symbol-description: error

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-prettier-doc": "^1.1.0",
         "jest": "^30.0.0-alpha.3",
         "jest-runner-eslint": "^2.1.2"
     },

--- a/tests/switch-plugin/index.js
+++ b/tests/switch-plugin/index.js
@@ -1,5 +1,5 @@
 const prettier = require("prettier");
-const { concat, indent, hardline } = prettier.doc.builders;
+const { indent, hardline } = prettier.doc.builders;
 const {
     STRING_NEEDS_QUOTES,
     printSingleTwigTag,
@@ -16,7 +16,7 @@ const printSwitch = (node, path, print) => {
     node.sections.forEach((section, i) => {
         if (Node.isGenericTwigTag(section)) {
             if (section.tagName === "endswitch") {
-                parts.push(concat([hardline, printedSections[i]]));
+                parts.push([hardline, printedSections[i]]);
             } else {
                 parts.push(indentWithHardline(printedSections[i]));
             }
@@ -27,7 +27,7 @@ const printSwitch = (node, path, print) => {
             }
         }
     });
-    return concat(parts);
+    return parts;
 };
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1606,6 +1606,11 @@ eslint-plugin-jest@^27.9.0:
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
+eslint-plugin-prettier-doc@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier-doc/-/eslint-plugin-prettier-doc-1.1.0.tgz#ebf679b480e6048e90d5b152e6043714780bb4e6"
+  integrity sha512-ytzztiiqobTeYLqdRnv+dgowcb63gFFy31RekPeVPB6YOshwuGKJVKPdkq/mYtwsJ+eDtLiHksfwH5/M5nU09g==
+
 eslint-plugin-prettier@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"


### PR DESCRIPTION
`concat` function has been deprecated since prettier 2.3.0.