### PR TITLE
Chore: Remove npm script to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 ## unreleased
 
+### Internals
+-   Remove npm script to publish
+
 ---
 ## v0.6.0 (2024-03-27)
 
 ### Features
-- BREAKING: Change package name `prettier-plugin-twig-melody` -> `@zackad/prettier-plugin-twig-melody`
+-   BREAKING: Change package name `prettier-plugin-twig-melody` -> `@zackad/prettier-plugin-twig-melody`
 
 ### Internals
-- Publish package as `@zackad/prettier-plugin-twig-melody` into npm registry
+-   Publish package as `@zackad/prettier-plugin-twig-melody` into npm registry
 
 ---
 ## v0.5.0

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "scripts": {
         "lint": "jest -c jest.eslint.config.js",
         "test": "jest",
-        "prettier": "prettier --plugin=. --parser=melody",
-        "publish": "npm publish"
+        "prettier": "prettier --plugin=. --parser=melody"
     },
     "dependencies": {
         "babel-types": "^6.26.0",


### PR DESCRIPTION
Ref: https://stackoverflow.com/a/72176325/6265296

When publishing to npm, the existence of npm script named 'publish' will trigger publishing packages twice for the same version.